### PR TITLE
Comment block updated.

### DIFF
--- a/pig-mode.el
+++ b/pig-mode.el
@@ -33,7 +33,7 @@
 
 ;; pig-mode is an Emacs major mode for editing Pig scripts. Currently it
 ;; supports syntax highlighting and indentation for Pig versions 0.2 to
-;; 0.7. We track the changes to Pig syntax and try to support new Pig
+;; 0.10. We track the changes to Pig syntax and try to support new Pig
 ;; features ASAP.
 
 ;;; Installation:


### PR DESCRIPTION
Forgot to add 0.10 support in the elisp's comment block.  I should have merged your whitespace edits too in this version if I did everything right.
