### PR TITLE
(pig-basic-functions): all elements must be upcase because that is how t...

### DIFF
--- a/pig-mode.el
+++ b/pig-mode.el
@@ -146,7 +146,7 @@
     "COUNT"
     "COUNT_STAR"
     "DIFF"
-    "IsEmpty"
+    "ISEMPTY"
     "MAX"
     "MIN"
     "SIZE"


### PR DESCRIPTION
...he constant is used
